### PR TITLE
skeleton code to pull repair content off Hilton

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ http://localhost:5000
 - [OpenAi API reference](https://platform.openai.com/docs/api-reference/introduction)
 - [ScrapeOps Proxy Aggregator](https://scrapeops.io/app/register/proxy)
 - [ScrapeOps Web Scraping Playbook ](https://scrapeops.io/web-scraping-playbook/403-forbidden-error-web-scraping/)
+- [Chilton's library for car diagnostic manuals](https://link.gale.com/apps/CHLL)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 - Install Python version 3.11 (pyenv recommended)
 - Run the `install_dependencies.sh` script to install requirements and setup a virtual environment (`.venv`)
 - Activate the virtual environment `source .venv/bin/activate`
-- Create `.env` file and populate it with API keys:
+- Create `.env` file and populate it with API keys (see "Resources" section for links):
     - `OPENAI_API_KEY`
+    - `SCRAPEOPS_API_KEY`
 
 # Running Locally
 Run the `run_app.sh` script to start a local instance of the application:
@@ -32,3 +33,5 @@ http://localhost:5000
 
 # Resources
 - [OpenAi API reference](https://platform.openai.com/docs/api-reference/introduction)
+- [ScrapeOps Proxy Aggregator](https://scrapeops.io/app/register/proxy)
+- [ScrapeOps Web Scraping Playbook ](https://scrapeops.io/web-scraping-playbook/403-forbidden-error-web-scraping/)

--- a/data_scraping/scrape_chiltons.py
+++ b/data_scraping/scrape_chiltons.py
@@ -1,6 +1,7 @@
 """Initial experiment to see if we can scrape Chilton's
 """
 
+import json
 import requests
 from bs4 import BeautifulSoup
 
@@ -12,9 +13,8 @@ HEADERS = {
     # "Referer": "https://google.com",
     # "Accept-Language": "en-US,en;q=0.9",
     # "User-Agent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
-    "Authorization": "Bearer eyJraWQiOiIyMTU3NDU1ODE1NjA3NzI5NjY4Mjc4Mzc4MzYwNDg3MjE2NzU5ODMiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJDaGlsdG9uTGlicmFyeS5jb20iLCJhdWQiOiJHYWxlIiwic3ViIjoiZ2FpbnN0b2Z0ZWNoIiwiaWF0IjoxNzA5MzkyNjQ5LCJleHAiOjE3MDkzOTYyNDksInZlciI6IjIiLCJsb2NhdGlvbl9pZCI6ImdhaW5zdG9mdGVjaCIsImxvY2F0aW9uX3RpdGxlIjoiR2VvcmdpYSBJbnN0aXR1dGUgT2YgVGVjaG5vbG9neSIsImluc3RpdHV0aW9uX2lkIjoiZ2Vvcmdpb3QiLCJpbnN0aXR1dGlvbl90aXRsZSI6IiIsImNvdW50cnkiOiJVUyIsInJlZ2lvbiI6IkdBIiwiYXV0aF90eXBlIjoic2hpYmJvbGV0aCIsImNsaWVudF9pcCI6IjEzMC40NC4xNDkuMTYiLCJ1YSI6IjE2OTEyMTQ1IiwibGFuZ19pZCI6IjEiLCJsYXVuY2hfZG9tYWluIjoiZ2FsZS5jb20iLCJhdXRoX3NlcnZlciI6Imh0dHBzOi8vaW5mb3RyYWMuZ2FsZS5jb20vZ2FsZW5ldC9nYWluc3RvZnRlY2giLCJtZW51X3NlcnZlciI6Imh0dHBzOi8vbGluay5nYWxlLmNvbS9hcHBzL21lbnU_dXNlckdyb3VwTmFtZT1nYWluc3RvZnRlY2giLCJzZXNzaW9uX2lkIjoiMTcwOTM5MjY0OTYxMGdhaW5zdG9mdGVjaCIsInVpX3ByZWZlcmVuY2UiOiJnYWxlbmV0IiwicHJvZHVjdF9pZCI6IkNITEwiLCJleHBpcmF0aW9uIjoiMjAyNDAzMDMxNTE3MjkgR01UIiwibGljZW5zZV90b2tlbiI6bnVsbCwibGljZW5zZV9saW1pdCI6LTEsImJyYW5kaW5nX3NjcmlwdCI6IiAiLCJicmFuZGluZ190ZXh0IjoiICIsInNjb3BlIjoicmVhZCJ9.Ql32KsUXuNlDDZLl7-jHm5oowQ4Wuphomu6aQI4CqoCsvqVb3V-b1GNRptqyGfCkfvcIwsFlKe3iKkoJOmFFk2Kbd0TUqZL3wgzU42w6t8IgT9nonZjB6C5as0s22VTcfnDiYFAr7m_VZqGRt6RfNu6B4MkBkVp7-djVpUyQCzROG42I5Meoh7CRrY_iKMuNFRk7aXlyaark8YCXQFFGWJRkzsIY_NyVDat3_EpNDTCyOVv8jaWzVv9UD8I0nFwVdqzn-t4rkLpLJ-v2rlqVeSLo90SnC1vz6Iy7EVYX5DnFp_wYZwdeeLZziu6t37G3081xEmmoInr_QCK-away7A"
+    "Authorization": "Bearer eyJraWQiOiIyMTU3NDU1ODE1NjA3NzI5NjY4Mjc4Mzc4MzYwNDg3MjE2NzU5ODMiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJDaGlsdG9uTGlicmFyeS5jb20iLCJhdWQiOiJHYWxlIiwic3ViIjoic3BsX21haW4iLCJpYXQiOjE3MDk3OTE0MDgsImV4cCI6MTcwOTc5NTAwOCwidmVyIjoiMiIsImxvY2F0aW9uX2lkIjoic3BsX21haW4iLCJsb2NhdGlvbl90aXRsZSI6IlNlYXR0bGUgUHVibGljIExpYnJhcnkiLCJpbnN0aXR1dGlvbl9pZCI6InNwbCIsImluc3RpdHV0aW9uX3RpdGxlIjoiIiwiY291bnRyeSI6IlVTIiwicmVnaW9uIjoiV0EiLCJhdXRoX3R5cGUiOiJpcCIsImNsaWVudF9pcCI6IjY2LjIxMi42NS4yMTUiLCJ1YSI6IjUwOTkwODY1IiwibGFuZ19pZCI6IjEiLCJsYXVuY2hfZG9tYWluIjoiZ2FsZS5jb20iLCJhdXRoX3NlcnZlciI6Imh0dHBzOi8vaW5mb3RyYWMuZ2FsZS5jb20vZ2FsZW5ldC9zcGxfbWFpbiIsIm1lbnVfc2VydmVyIjoiaHR0cHM6Ly9saW5rLmdhbGUuY29tL2FwcHMvbWVudT91c2VyR3JvdXBOYW1lPXNwbF9tYWluIiwic2Vzc2lvbl9pZCI6IjE3MDk3NzY3ODM2ODFzcGxfbWFpbiIsInVpX3ByZWZlcmVuY2UiOiJnYWxlbmV0IiwicHJvZHVjdF9pZCI6IkNITEwiLCJleHBpcmF0aW9uIjoiMjAyNDAzMDgwMTU5NDMgR01UIiwibGljZW5zZV90b2tlbiI6bnVsbCwibGljZW5zZV9saW1pdCI6LTEsImJyYW5kaW5nX3NjcmlwdCI6Imh0dHBzOi8vYXNzZXRzLmNlbmdhZ2UuY29tL2dhbGUvYnJhbmRpbmcvY29uc29ydGlhL3dzbC5qcyIsImJyYW5kaW5nX3RleHQiOiIgIiwic2NvcGUiOiJyZWFkIn0.qEY0PbelEuyliAY5Vr0tj-e68Hbyf4ik7Jo1cVo3irZhfI8qrQQTCBoiLui-zPLl-um-seHifqFfzfvJ78WMJzvQVRDBfS3L6wRhhYsdJnMa1V4DGEcKCrc9ySnRo3Ko6x6KzjmNPFz1Kjq8GsktmBZRhprapsvnDARsMW9031tNQHXMai6-IS9aMHFtdfe29mrbiJBUUhd7KCmysCZLc3ylefdleBBR-Lay2gwfGFHP05CLIiaTcKDmHFg_SS--CgWB2_kdZh9g7ifdcUULeeuQUnFzRkpFcDg0os-hgUWiOeG0KYQ0Uy2O2KMfIWz3BMmDofoNhkt1eRd7QMtamA"
 }
-
 
 url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/make/2017'
 def get_makes():
@@ -23,6 +23,7 @@ def get_makes():
     makes = [x['make'] for x in response.json()['makes']]
     assert 'Nissan' in makes
     return makes
+
 print(get_makes())
 
 url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/model/2017/Nissan'
@@ -47,8 +48,35 @@ def get_car_base():
 base_vehicle_id = get_car_base()['baseVehicleId']
 
 url = f'https://appapi.chiltonlibrary.com/chilton-repair-service/toc/{base_vehicle_id}'
+
 def get_table_of_contents():
     # Send a GET request to the website
     response = requests.get(url, headers=HEADERS)
     return response.json()
-print(get_table_of_contents())
+
+toc = get_table_of_contents()
+
+with open (f"./json_dump/{base_vehicle_id}.json", "w") as fo:
+     json.dump(toc, fo, ensure_ascii = False) 
+
+
+url = 'https://appapi-chiltonlibrary-com.ezproxy.spl.org/chilton-repair-service/toc/articlelist/140871/115931'
+toc = get_table_of_contents()
+
+
+
+url = 'https://appapi-chiltonlibrary-com.ezproxy.spl.org/chilton-repair-service/toc/article'
+data = {"bvid":140871,"articleIds":["330366"],"parentTocName":"Frame Straightening","parentTocId":115931}
+HEADERS.update(
+{'Content-type':'application/json', 
+    'Accept':'application/json'
+})
+
+response = requests.post(url, 
+    json = data,
+    headers = HEADERS,
+)
+
+print(response.json())
+
+

--- a/data_scraping/scrape_chiltons.py
+++ b/data_scraping/scrape_chiltons.py
@@ -1,0 +1,28 @@
+"""Initial experiment to see if we can scrape Chilton's
+"""
+
+import requests
+from bs4 import BeautifulSoup
+
+# URL of the website you want to scrape
+url = 'https://app.chiltonlibrary.com/home?id_token=eyJraWQiOiIyMTU3NDU1ODE1NjA3NzI5NjY4Mjc4Mzc4MzYwNDg3MjE2NzU5ODMiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJDaGlsdG9uTGlicmFyeS5jb20iLCJhdWQiOiJHYWxlIiwic3ViIjoiZ2FpbnN0b2Z0ZWNoIiwiaWF0IjoxNzA4MzA4MzQ1LCJleHAiOjE3MDgzMTE5NDUsInZlciI6IjIiLCJsb2NhdGlvbl9pZCI6ImdhaW5zdG9mdGVjaCIsImxvY2F0aW9uX3RpdGxlIjoiR2VvcmdpYSBJbnN0aXR1dGUgT2YgVGVjaG5vbG9neSIsImluc3RpdHV0aW9uX2lkIjoiZ2Vvcmdpb3QiLCJpbnN0aXR1dGlvbl90aXRsZSI6IiIsImNvdW50cnkiOiJVUyIsInJlZ2lvbiI6IkdBIiwiYXV0aF90eXBlIjoic2hpYmJvbGV0aCIsImNsaWVudF9pcCI6Ijk5LjI2LjE0MC4yMTciLCJ1YSI6IjQxOTQ5OTM1NyIsImxhbmdfaWQiOiIxIiwibGF1bmNoX2RvbWFpbiI6ImdhbGUuY29tIiwiYXV0aF9zZXJ2ZXIiOiJodHRwczovL2luZm90cmFjLmdhbGUuY29tL2dhbGVuZXQvZ2FpbnN0b2Z0ZWNoIiwibWVudV9zZXJ2ZXIiOiJodHRwczovL2xpbmsuZ2FsZS5jb20vYXBwcy9tZW51P3VzZXJHcm91cE5hbWU9Z2FpbnN0b2Z0ZWNoIiwic2Vzc2lvbl9pZCI6IjE3MDgzMDgzNDU1NDZnYWluc3RvZnRlY2giLCJ1aV9wcmVmZXJlbmNlIjoiZ2FsZW5ldCIsInByb2R1Y3RfaWQiOiJDSExMIiwiZXhwaXJhdGlvbiI6IjIwMjQwMjIwMDIwNTQ1IEdNVCIsImxpY2Vuc2VfdG9rZW4iOm51bGwsImxpY2Vuc2VfbGltaXQiOi0xLCJicmFuZGluZ19zY3JpcHQiOiIgIiwiYnJhbmRpbmdfdGV4dCI6IiAiLCJzY29wZSI6InJlYWQifQ.sMw7vzL0p0kZWTKPjtgrutsIg31mTzVuB6fQl6BCRCl9kVGEs5Mo1fafi_ma7N7JB-R44Uh8WfzrsHgyWfP8DZyLIM8ERzeafVwo-OGP0AY1LY_mNkAPfy6qdXxj96suJNsaDyT-UL6txxBKAxu8lUiTv0SiNizbhzDiGVp5edX6LAC434aRNDihU8qgK0Mkp1lEOO-CZBUPTTY1q32rNzy6gx7rJR7J1yUNTvOYd1YGO2D721Lwy1hPqG_gFtvjSLUdLBPUzQgBXMoqTDpDT9ppHOZqYbqtnOiUW7jUYA9K_VUrVv0_13AkBzHPAnibJGR2lRgwd8ZcWXAyhct2GA'
+
+
+HEADERS = {
+    "Referer": "https://google.com",
+    "Accept-Language": "en-US,en;q=0.9",
+    "User-Agent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+}
+
+# Send a GET request to the website
+response = requests.get(url, headers=HEADERS)
+
+print(response.text)
+print(response)
+
+# Check if the request was successful
+if response.status_code == 200:
+    # Parse the HTML content of the page
+    soup = BeautifulSoup(response.content, 'html.parser')
+
+    print(soup)

--- a/data_scraping/scrape_chiltons.py
+++ b/data_scraping/scrape_chiltons.py
@@ -5,24 +5,50 @@ import requests
 from bs4 import BeautifulSoup
 
 # URL of the website you want to scrape
-url = 'https://app.chiltonlibrary.com/home?id_token=eyJraWQiOiIyMTU3NDU1ODE1NjA3NzI5NjY4Mjc4Mzc4MzYwNDg3MjE2NzU5ODMiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJDaGlsdG9uTGlicmFyeS5jb20iLCJhdWQiOiJHYWxlIiwic3ViIjoiZ2FpbnN0b2Z0ZWNoIiwiaWF0IjoxNzA4MzA4MzQ1LCJleHAiOjE3MDgzMTE5NDUsInZlciI6IjIiLCJsb2NhdGlvbl9pZCI6ImdhaW5zdG9mdGVjaCIsImxvY2F0aW9uX3RpdGxlIjoiR2VvcmdpYSBJbnN0aXR1dGUgT2YgVGVjaG5vbG9neSIsImluc3RpdHV0aW9uX2lkIjoiZ2Vvcmdpb3QiLCJpbnN0aXR1dGlvbl90aXRsZSI6IiIsImNvdW50cnkiOiJVUyIsInJlZ2lvbiI6IkdBIiwiYXV0aF90eXBlIjoic2hpYmJvbGV0aCIsImNsaWVudF9pcCI6Ijk5LjI2LjE0MC4yMTciLCJ1YSI6IjQxOTQ5OTM1NyIsImxhbmdfaWQiOiIxIiwibGF1bmNoX2RvbWFpbiI6ImdhbGUuY29tIiwiYXV0aF9zZXJ2ZXIiOiJodHRwczovL2luZm90cmFjLmdhbGUuY29tL2dhbGVuZXQvZ2FpbnN0b2Z0ZWNoIiwibWVudV9zZXJ2ZXIiOiJodHRwczovL2xpbmsuZ2FsZS5jb20vYXBwcy9tZW51P3VzZXJHcm91cE5hbWU9Z2FpbnN0b2Z0ZWNoIiwic2Vzc2lvbl9pZCI6IjE3MDgzMDgzNDU1NDZnYWluc3RvZnRlY2giLCJ1aV9wcmVmZXJlbmNlIjoiZ2FsZW5ldCIsInByb2R1Y3RfaWQiOiJDSExMIiwiZXhwaXJhdGlvbiI6IjIwMjQwMjIwMDIwNTQ1IEdNVCIsImxpY2Vuc2VfdG9rZW4iOm51bGwsImxpY2Vuc2VfbGltaXQiOi0xLCJicmFuZGluZ19zY3JpcHQiOiIgIiwiYnJhbmRpbmdfdGV4dCI6IiAiLCJzY29wZSI6InJlYWQifQ.sMw7vzL0p0kZWTKPjtgrutsIg31mTzVuB6fQl6BCRCl9kVGEs5Mo1fafi_ma7N7JB-R44Uh8WfzrsHgyWfP8DZyLIM8ERzeafVwo-OGP0AY1LY_mNkAPfy6qdXxj96suJNsaDyT-UL6txxBKAxu8lUiTv0SiNizbhzDiGVp5edX6LAC434aRNDihU8qgK0Mkp1lEOO-CZBUPTTY1q32rNzy6gx7rJR7J1yUNTvOYd1YGO2D721Lwy1hPqG_gFtvjSLUdLBPUzQgBXMoqTDpDT9ppHOZqYbqtnOiUW7jUYA9K_VUrVv0_13AkBzHPAnibJGR2lRgwd8ZcWXAyhct2GA'
-
+# url = 'https://app.chiltonlibrary.com/home?id_token=eyJraWQiOiIyMTU3NDU1ODE1NjA3NzI5NjY4Mjc4Mzc4MzYwNDg3MjE2NzU5ODMiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJDaGlsdG9uTGlicmFyeS5jb20iLCJhdWQiOiJHYWxlIiwic3ViIjoiZ2FpbnN0b2Z0ZWNoIiwiaWF0IjoxNzA4MzA4MzQ1LCJleHAiOjE3MDgzMTE5NDUsInZlciI6IjIiLCJsb2NhdGlvbl9pZCI6ImdhaW5zdG9mdGVjaCIsImxvY2F0aW9uX3RpdGxlIjoiR2VvcmdpYSBJbnN0aXR1dGUgT2YgVGVjaG5vbG9neSIsImluc3RpdHV0aW9uX2lkIjoiZ2Vvcmdpb3QiLCJpbnN0aXR1dGlvbl90aXRsZSI6IiIsImNvdW50cnkiOiJVUyIsInJlZ2lvbiI6IkdBIiwiYXV0aF90eXBlIjoic2hpYmJvbGV0aCIsImNsaWVudF9pcCI6Ijk5LjI2LjE0MC4yMTciLCJ1YSI6IjQxOTQ5OTM1NyIsImxhbmdfaWQiOiIxIiwibGF1bmNoX2RvbWFpbiI6ImdhbGUuY29tIiwiYXV0aF9zZXJ2ZXIiOiJodHRwczovL2luZm90cmFjLmdhbGUuY29tL2dhbGVuZXQvZ2FpbnN0b2Z0ZWNoIiwibWVudV9zZXJ2ZXIiOiJodHRwczovL2xpbmsuZ2FsZS5jb20vYXBwcy9tZW51P3VzZXJHcm91cE5hbWU9Z2FpbnN0b2Z0ZWNoIiwic2Vzc2lvbl9pZCI6IjE3MDgzMDgzNDU1NDZnYWluc3RvZnRlY2giLCJ1aV9wcmVmZXJlbmNlIjoiZ2FsZW5ldCIsInByb2R1Y3RfaWQiOiJDSExMIiwiZXhwaXJhdGlvbiI6IjIwMjQwMjIwMDIwNTQ1IEdNVCIsImxpY2Vuc2VfdG9rZW4iOm51bGwsImxpY2Vuc2VfbGltaXQiOi0xLCJicmFuZGluZ19zY3JpcHQiOiIgIiwiYnJhbmRpbmdfdGV4dCI6IiAiLCJzY29wZSI6InJlYWQifQ.sMw7vzL0p0kZWTKPjtgrutsIg31mTzVuB6fQl6BCRCl9kVGEs5Mo1fafi_ma7N7JB-R44Uh8WfzrsHgyWfP8DZyLIM8ERzeafVwo-OGP0AY1LY_mNkAPfy6qdXxj96suJNsaDyT-UL6txxBKAxu8lUiTv0SiNizbhzDiGVp5edX6LAC434aRNDihU8qgK0Mkp1lEOO-CZBUPTTY1q32rNzy6gx7rJR7J1yUNTvOYd1YGO2D721Lwy1hPqG_gFtvjSLUdLBPUzQgBXMoqTDpDT9ppHOZqYbqtnOiUW7jUYA9K_VUrVv0_13AkBzHPAnibJGR2lRgwd8ZcWXAyhct2GA'
+url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/make/2024'
 
 HEADERS = {
-    "Referer": "https://google.com",
-    "Accept-Language": "en-US,en;q=0.9",
-    "User-Agent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+    # "Referer": "https://google.com",
+    # "Accept-Language": "en-US,en;q=0.9",
+    # "User-Agent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+    "Authorization": "Bearer eyJraWQiOiIyMTU3NDU1ODE1NjA3NzI5NjY4Mjc4Mzc4MzYwNDg3MjE2NzU5ODMiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJDaGlsdG9uTGlicmFyeS5jb20iLCJhdWQiOiJHYWxlIiwic3ViIjoiZ2FpbnN0b2Z0ZWNoIiwiaWF0IjoxNzA5MzkyNjQ5LCJleHAiOjE3MDkzOTYyNDksInZlciI6IjIiLCJsb2NhdGlvbl9pZCI6ImdhaW5zdG9mdGVjaCIsImxvY2F0aW9uX3RpdGxlIjoiR2VvcmdpYSBJbnN0aXR1dGUgT2YgVGVjaG5vbG9neSIsImluc3RpdHV0aW9uX2lkIjoiZ2Vvcmdpb3QiLCJpbnN0aXR1dGlvbl90aXRsZSI6IiIsImNvdW50cnkiOiJVUyIsInJlZ2lvbiI6IkdBIiwiYXV0aF90eXBlIjoic2hpYmJvbGV0aCIsImNsaWVudF9pcCI6IjEzMC40NC4xNDkuMTYiLCJ1YSI6IjE2OTEyMTQ1IiwibGFuZ19pZCI6IjEiLCJsYXVuY2hfZG9tYWluIjoiZ2FsZS5jb20iLCJhdXRoX3NlcnZlciI6Imh0dHBzOi8vaW5mb3RyYWMuZ2FsZS5jb20vZ2FsZW5ldC9nYWluc3RvZnRlY2giLCJtZW51X3NlcnZlciI6Imh0dHBzOi8vbGluay5nYWxlLmNvbS9hcHBzL21lbnU_dXNlckdyb3VwTmFtZT1nYWluc3RvZnRlY2giLCJzZXNzaW9uX2lkIjoiMTcwOTM5MjY0OTYxMGdhaW5zdG9mdGVjaCIsInVpX3ByZWZlcmVuY2UiOiJnYWxlbmV0IiwicHJvZHVjdF9pZCI6IkNITEwiLCJleHBpcmF0aW9uIjoiMjAyNDAzMDMxNTE3MjkgR01UIiwibGljZW5zZV90b2tlbiI6bnVsbCwibGljZW5zZV9saW1pdCI6LTEsImJyYW5kaW5nX3NjcmlwdCI6IiAiLCJicmFuZGluZ190ZXh0IjoiICIsInNjb3BlIjoicmVhZCJ9.Ql32KsUXuNlDDZLl7-jHm5oowQ4Wuphomu6aQI4CqoCsvqVb3V-b1GNRptqyGfCkfvcIwsFlKe3iKkoJOmFFk2Kbd0TUqZL3wgzU42w6t8IgT9nonZjB6C5as0s22VTcfnDiYFAr7m_VZqGRt6RfNu6B4MkBkVp7-djVpUyQCzROG42I5Meoh7CRrY_iKMuNFRk7aXlyaark8YCXQFFGWJRkzsIY_NyVDat3_EpNDTCyOVv8jaWzVv9UD8I0nFwVdqzn-t4rkLpLJ-v2rlqVeSLo90SnC1vz6Iy7EVYX5DnFp_wYZwdeeLZziu6t37G3081xEmmoInr_QCK-away7A"
 }
 
-# Send a GET request to the website
-response = requests.get(url, headers=HEADERS)
 
-print(response.text)
-print(response)
+url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/make/2017'
+def get_makes():
+    # Send a GET request to the website
+    response = requests.get(url, headers=HEADERS)
+    makes = [x['make'] for x in response.json()['makes']]
+    assert 'Nissan' in makes
+    return makes
+print(get_makes())
 
-# Check if the request was successful
-if response.status_code == 200:
-    # Parse the HTML content of the page
-    soup = BeautifulSoup(response.content, 'html.parser')
+url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/model/2017/Nissan'
+def get_models():
+    # Send a GET request to the website
+    response = requests.get(url, headers=HEADERS)
+    models = [x['model'] for x in response.json()['models']]
+    assert 'Rogue' in models
+    return models
+print(get_models())
 
-    print(soup)
+url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/basevehicle'
+def get_car_base():
+    request_payload = {
+        'make': 'Nissan',
+        'model': 'Rogue',
+        'year': 2017
+    }
+    # Send a GET request to the website
+    response = requests.post(url, json=request_payload, headers=HEADERS)
+    return response.json()
+base_vehicle_id = get_car_base()['baseVehicleId']
+
+url = f'https://appapi.chiltonlibrary.com/chilton-repair-service/toc/{base_vehicle_id}'
+def get_table_of_contents():
+    # Send a GET request to the website
+    response = requests.get(url, headers=HEADERS)
+    return response.json()
+print(get_table_of_contents())

--- a/data_scraping/scrape_chiltons.py
+++ b/data_scraping/scrape_chiltons.py
@@ -9,14 +9,19 @@ from bs4 import BeautifulSoup
 # url = 'https://app.chiltonlibrary.com/home?id_token=eyJraWQiOiIyMTU3NDU1ODE1NjA3NzI5NjY4Mjc4Mzc4MzYwNDg3MjE2NzU5ODMiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJDaGlsdG9uTGlicmFyeS5jb20iLCJhdWQiOiJHYWxlIiwic3ViIjoiZ2FpbnN0b2Z0ZWNoIiwiaWF0IjoxNzA4MzA4MzQ1LCJleHAiOjE3MDgzMTE5NDUsInZlciI6IjIiLCJsb2NhdGlvbl9pZCI6ImdhaW5zdG9mdGVjaCIsImxvY2F0aW9uX3RpdGxlIjoiR2VvcmdpYSBJbnN0aXR1dGUgT2YgVGVjaG5vbG9neSIsImluc3RpdHV0aW9uX2lkIjoiZ2Vvcmdpb3QiLCJpbnN0aXR1dGlvbl90aXRsZSI6IiIsImNvdW50cnkiOiJVUyIsInJlZ2lvbiI6IkdBIiwiYXV0aF90eXBlIjoic2hpYmJvbGV0aCIsImNsaWVudF9pcCI6Ijk5LjI2LjE0MC4yMTciLCJ1YSI6IjQxOTQ5OTM1NyIsImxhbmdfaWQiOiIxIiwibGF1bmNoX2RvbWFpbiI6ImdhbGUuY29tIiwiYXV0aF9zZXJ2ZXIiOiJodHRwczovL2luZm90cmFjLmdhbGUuY29tL2dhbGVuZXQvZ2FpbnN0b2Z0ZWNoIiwibWVudV9zZXJ2ZXIiOiJodHRwczovL2xpbmsuZ2FsZS5jb20vYXBwcy9tZW51P3VzZXJHcm91cE5hbWU9Z2FpbnN0b2Z0ZWNoIiwic2Vzc2lvbl9pZCI6IjE3MDgzMDgzNDU1NDZnYWluc3RvZnRlY2giLCJ1aV9wcmVmZXJlbmNlIjoiZ2FsZW5ldCIsInByb2R1Y3RfaWQiOiJDSExMIiwiZXhwaXJhdGlvbiI6IjIwMjQwMjIwMDIwNTQ1IEdNVCIsImxpY2Vuc2VfdG9rZW4iOm51bGwsImxpY2Vuc2VfbGltaXQiOi0xLCJicmFuZGluZ19zY3JpcHQiOiIgIiwiYnJhbmRpbmdfdGV4dCI6IiAiLCJzY29wZSI6InJlYWQifQ.sMw7vzL0p0kZWTKPjtgrutsIg31mTzVuB6fQl6BCRCl9kVGEs5Mo1fafi_ma7N7JB-R44Uh8WfzrsHgyWfP8DZyLIM8ERzeafVwo-OGP0AY1LY_mNkAPfy6qdXxj96suJNsaDyT-UL6txxBKAxu8lUiTv0SiNizbhzDiGVp5edX6LAC434aRNDihU8qgK0Mkp1lEOO-CZBUPTTY1q32rNzy6gx7rJR7J1yUNTvOYd1YGO2D721Lwy1hPqG_gFtvjSLUdLBPUzQgBXMoqTDpDT9ppHOZqYbqtnOiUW7jUYA9K_VUrVv0_13AkBzHPAnibJGR2lRgwd8ZcWXAyhct2GA'
 url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/make/2024'
 
+TOKEN = 'eyJraWQiOiIyMTU3NDU1ODE1NjA3NzI5NjY4Mjc4Mzc4MzYwNDg3MjE2NzU5ODMiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJDaGlsdG9uTGlicmFyeS5jb20iLCJhdWQiOiJHYWxlIiwic3ViIjoic3BsX21haW4iLCJpYXQiOjE3MTAxMzM4MzIsImV4cCI6MTcxMDEzNzQzMiwidmVyIjoiMiIsImxvY2F0aW9uX2lkIjoic3BsX21haW4iLCJsb2NhdGlvbl90aXRsZSI6IlNlYXR0bGUgUHVibGljIExpYnJhcnkiLCJpbnN0aXR1dGlvbl9pZCI6InNwbCIsImluc3RpdHV0aW9uX3RpdGxlIjoiIiwiY291bnRyeSI6IlVTIiwicmVnaW9uIjoiV0EiLCJhdXRoX3R5cGUiOiJpcCIsImNsaWVudF9pcCI6IjY2LjIxMi42NS4yMTUiLCJ1YSI6IjUwOTkwODY1IiwibGFuZ19pZCI6IjEiLCJsYXVuY2hfZG9tYWluIjoiZ2FsZS5jb20iLCJhdXRoX3NlcnZlciI6Imh0dHBzOi8vaW5mb3RyYWMuZ2FsZS5jb20vZ2FsZW5ldC9zcGxfbWFpbiIsIm1lbnVfc2VydmVyIjoiaHR0cHM6Ly9saW5rLmdhbGUuY29tL2FwcHMvbWVudT91c2VyR3JvdXBOYW1lPXNwbF9tYWluIiwic2Vzc2lvbl9pZCI6IjE3MTAxMzM4MzI5MzlzcGxfbWFpbiIsInVpX3ByZWZlcmVuY2UiOiJnYWxlbmV0IiwicHJvZHVjdF9pZCI6IkNITEwiLCJleHBpcmF0aW9uIjoiMjAyNDAzMTIwNTEwMzIgR01UIiwibGljZW5zZV90b2tlbiI6bnVsbCwibGljZW5zZV9saW1pdCI6LTEsImJyYW5kaW5nX3NjcmlwdCI6Imh0dHBzOi8vYXNzZXRzLmNlbmdhZ2UuY29tL2dhbGUvYnJhbmRpbmcvY29uc29ydGlhL3dzbC5qcyIsImJyYW5kaW5nX3RleHQiOiIgIiwic2NvcGUiOiJyZWFkIn0.YQuB9oDkubtCXRtlYQnKe0V2kXfZpxJNXyI2UYVXzmvuQbImVgRuhMoQP2Ga2i96bgmxjCI-Plka1Dh5qIgWfvZ_177aK-nL8slnNIuDuWyHDumU5m0G7FGphCxKq4YJVBveSUs25uNwFr_d3yIyJECpU21kvr2CJ2DdcuQfHR6cOhChNkaaF6ME3wn39pc1D_nnTm1DTm1Y6Jl1x6XhYFjInZq45ZS5Wijh_zHXzSVGzHSQ_68Okv8SlZnG_meX18ZFYNZvlbPmyql4SUSD808i0zAlfiNpB3I56c0YfGviILNFlg7WoKq2pFSNFevMNLt-B63o0AgfnhdV6aYt_g'
+
 HEADERS = {
     # "Referer": "https://google.com",
     # "Accept-Language": "en-US,en;q=0.9",
     # "User-Agent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
-    "Authorization": "Bearer eyJraWQiOiIyMTU3NDU1ODE1NjA3NzI5NjY4Mjc4Mzc4MzYwNDg3MjE2NzU5ODMiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJDaGlsdG9uTGlicmFyeS5jb20iLCJhdWQiOiJHYWxlIiwic3ViIjoic3BsX21haW4iLCJpYXQiOjE3MDk3OTE0MDgsImV4cCI6MTcwOTc5NTAwOCwidmVyIjoiMiIsImxvY2F0aW9uX2lkIjoic3BsX21haW4iLCJsb2NhdGlvbl90aXRsZSI6IlNlYXR0bGUgUHVibGljIExpYnJhcnkiLCJpbnN0aXR1dGlvbl9pZCI6InNwbCIsImluc3RpdHV0aW9uX3RpdGxlIjoiIiwiY291bnRyeSI6IlVTIiwicmVnaW9uIjoiV0EiLCJhdXRoX3R5cGUiOiJpcCIsImNsaWVudF9pcCI6IjY2LjIxMi42NS4yMTUiLCJ1YSI6IjUwOTkwODY1IiwibGFuZ19pZCI6IjEiLCJsYXVuY2hfZG9tYWluIjoiZ2FsZS5jb20iLCJhdXRoX3NlcnZlciI6Imh0dHBzOi8vaW5mb3RyYWMuZ2FsZS5jb20vZ2FsZW5ldC9zcGxfbWFpbiIsIm1lbnVfc2VydmVyIjoiaHR0cHM6Ly9saW5rLmdhbGUuY29tL2FwcHMvbWVudT91c2VyR3JvdXBOYW1lPXNwbF9tYWluIiwic2Vzc2lvbl9pZCI6IjE3MDk3NzY3ODM2ODFzcGxfbWFpbiIsInVpX3ByZWZlcmVuY2UiOiJnYWxlbmV0IiwicHJvZHVjdF9pZCI6IkNITEwiLCJleHBpcmF0aW9uIjoiMjAyNDAzMDgwMTU5NDMgR01UIiwibGljZW5zZV90b2tlbiI6bnVsbCwibGljZW5zZV9saW1pdCI6LTEsImJyYW5kaW5nX3NjcmlwdCI6Imh0dHBzOi8vYXNzZXRzLmNlbmdhZ2UuY29tL2dhbGUvYnJhbmRpbmcvY29uc29ydGlhL3dzbC5qcyIsImJyYW5kaW5nX3RleHQiOiIgIiwic2NvcGUiOiJyZWFkIn0.qEY0PbelEuyliAY5Vr0tj-e68Hbyf4ik7Jo1cVo3irZhfI8qrQQTCBoiLui-zPLl-um-seHifqFfzfvJ78WMJzvQVRDBfS3L6wRhhYsdJnMa1V4DGEcKCrc9ySnRo3Ko6x6KzjmNPFz1Kjq8GsktmBZRhprapsvnDARsMW9031tNQHXMai6-IS9aMHFtdfe29mrbiJBUUhd7KCmysCZLc3ylefdleBBR-Lay2gwfGFHP05CLIiaTcKDmHFg_SS--CgWB2_kdZh9g7ifdcUULeeuQUnFzRkpFcDg0os-hgUWiOeG0KYQ0Uy2O2KMfIWz3BMmDofoNhkt1eRd7QMtamA"
+    "Authorization": f"Bearer {TOKEN}"
+
 }
 
-url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/make/2017'
+BASE_URL = 'https://appapi.chiltonlibrary.com'
+
+url = f'{BASE_URL}/chilton-vehicle-service/make/2017'
 def get_makes():
     # Send a GET request to the website
     response = requests.get(url, headers=HEADERS)
@@ -26,57 +31,82 @@ def get_makes():
 
 print(get_makes())
 
-url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/model/2017/Nissan'
+url = f'{BASE_URL}/chilton-vehicle-service/model/2017/Nissan'
 def get_models():
     # Send a GET request to the website
     response = requests.get(url, headers=HEADERS)
     models = [x['model'] for x in response.json()['models']]
     assert 'Rogue' in models
     return models
+
+
 print(get_models())
 
-url = 'https://appapi.chiltonlibrary.com/chilton-vehicle-service/basevehicle'
+
+url = f'{BASE_URL}/chilton-vehicle-service/basevehicle'
+
 def get_car_base():
     request_payload = {
         'make': 'Nissan',
         'model': 'Rogue',
         'year': 2017
     }
-    # Send a GET request to the website
+    # Send a POST request to the website
     response = requests.post(url, json=request_payload, headers=HEADERS)
     return response.json()
+
+
 base_vehicle_id = get_car_base()['baseVehicleId']
 
-url = f'https://appapi.chiltonlibrary.com/chilton-repair-service/toc/{base_vehicle_id}'
+print (base_vehicle_id)
 
-def get_table_of_contents():
+
+url = f'{BASE_URL}/chilton-repair-service/toc/{base_vehicle_id}'
+
+def get_request_basic():
     # Send a GET request to the website
     response = requests.get(url, headers=HEADERS)
     return response.json()
 
-toc = get_table_of_contents()
+toc = get_request_basic()
 
-with open (f"./json_dump/{base_vehicle_id}.json", "w") as fo:
-     json.dump(toc, fo, ensure_ascii = False) 
-
-
-url = 'https://appapi-chiltonlibrary-com.ezproxy.spl.org/chilton-repair-service/toc/articlelist/140871/115931'
-toc = get_table_of_contents()
+# with open (f"./json_dump/{base_vehicle_id}.json", "w") as fo:
+#      json.dump(toc, fo, ensure_ascii = False) 
 
 
 
-url = 'https://appapi-chiltonlibrary-com.ezproxy.spl.org/chilton-repair-service/toc/article'
+
+# examples of scraping repair content under "Body Exterior, Doors, Roof & Vehicle Security --> Body Repair --> Fundamentals --> Service Information --> Aluminum Repair --> Body Straightening (Aluminum) --> Frame Straightening"
+
+# step 1: get the IDs from available vehicles (e.g. Rogue, Rogue_HEV)
+# url right before the repair content ("Available Configurations" under "Frame Straightening" page)
+# 140871 <-- base_vehicle_id
+# 115931 <-- tocID in 'toc' before the repair content (e.g. 'Frame Straightening')
+
+url = f'{BASE_URL}/chilton-repair-service/toc/articlelist/140871/115931'
+avail_vehicles = get_request_basic()
+
+# step 2: get the repair content
+url = f'{BASE_URL}/chilton-repair-service/toc/article'
 data = {"bvid":140871,"articleIds":["330366"],"parentTocName":"Frame Straightening","parentTocId":115931}
+
+# bvid <-- base_vehicle_id
+# articleIds <-- articleIds in 'avail_vehicles'
+# parentTocId <-- tocID in 'toc' before the repair content (e.g. 'Frame Straightening')
+
+
 HEADERS.update(
 {'Content-type':'application/json', 
     'Accept':'application/json'
 })
 
-response = requests.post(url, 
+repair_response = requests.post(url, 
     json = data,
     headers = HEADERS,
 )
 
-print(response.json())
+print(repair_response.json())
 
+# TODO
+# add repair_response and avail_vehicles toc
 

--- a/data_scraping/scrape_ops.py
+++ b/data_scraping/scrape_ops.py
@@ -1,0 +1,15 @@
+from urllib.parse import urlencode
+
+import requests
+
+SCRAPEOPS_API_KEY = os.environ.get("SCRAPEOPS_API_KEY")
+
+def get_scrapeops_url(url):
+
+    payload = {'api_key': SCRAPEOPS_API_KEY, 'url': url}
+    proxy_url = 'https://proxy.scrapeops.io/v1/?' + urlencode(payload)
+    return proxy_url
+
+url_ = "https://link.gale.com/apps/CHLL"
+r = requests.get(get_scrapeops_url(url_))
+print(r.text)

--- a/requires/dev.txt
+++ b/requires/dev.txt
@@ -2,3 +2,5 @@
 mypy
 pylint
 black
+beautifulsoup4
+Scrapy


### PR DESCRIPTION
added a series of steps to pull repair content using repairing Rogue 2017 for frame straightening as an example.

Note that the _toc_ (table of content) resulted from _get_request_basic_ function only scrape the nested repair topics, not the actual repair instructions.

<img width="1295" alt="table_of_content" src="https://github.com/second-opinion-ai/second-opinion/assets/4030518/e030973c-5f0e-4597-9232-08315434ed40">
<img width="1308" alt="repair_content" src="https://github.com/second-opinion-ai/second-opinion/assets/4030518/a90721ae-9e37-4cb2-84b3-5934e5e3b848">
